### PR TITLE
Don't select icons + dropdown layout improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,7 +463,7 @@
     <div id="generalToolContainer">
         <div style="position: absolute; z-index: 9999997;">
             <div class="vertcenter column" id="toolMain" style="visibility: hidden;">
-                <div class="optionContainer vertcenter" id="containerOfOptions"
+                <div class="optionContainer vertcenter noselect"  id="containerOfOptions"
                     style="margin-top: 10px; height: 100%; padding-top: 5px; padding-bottom: 5px; overflow: auto;">
                     <div class="optionId" data-action="prev">
                         <img fetchlink="prev" draggable="false" class="imgTool">
@@ -515,11 +515,11 @@
         </div>
     </div>
     <div style="height: 80px;"></div>
-    <div class="vertcenter" id="pdfcontainer">
-        <div class="vertcenter column" id="pageContainer" style="visibility: hidden;">
-            <div id="canvasMargin">
-                <div class="pageBackground columnflex" id="canvasContainer">
-                    <canvas class="displayCanvas pointer" id="displayCanvas" height="600px" width="500px"
+    <div class="vertcenter noselect" id="pdfcontainer">
+        <div class="vertcenter column noselect" id="pageContainer" style="visibility: hidden;">
+            <div id="canvasMargin noselect">
+                <div class="pageBackground columnflex noselect" id="canvasContainer">
+                    <canvas class="displayCanvas pointer noselect" id="displayCanvas" height="600px" width="500px"
                         pdf="yes"></canvas>
                         <div class="vertcenter">
                             <div class="numberCircle">

--- a/index.html
+++ b/index.html
@@ -517,7 +517,7 @@
     <div style="height: 80px;"></div>
     <div class="vertcenter noselect" id="pdfcontainer">
         <div class="vertcenter column noselect" id="pageContainer" style="visibility: hidden;">
-            <div id="canvasMargin noselect">
+            <div id="canvasMargin" class="noselect">
                 <div class="pageBackground columnflex noselect" id="canvasContainer">
                     <canvas class="displayCanvas pointer noselect" id="displayCanvas" height="600px" width="500px"
                         pdf="yes"></canvas>

--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@
         </div>
     </div>
     <div id="welcomeClick" style="display: flex; height: 48px; justify-content: center; text-decoration: none;"
-        data-customanimate="1" class="linkWithoutBrightness">
+        data-customanimate="1" class="linkWithoutBrightness noselect">
         <img fetchlink="logo" draggable="false" width="48px" height="48px">
         <div style="display: flex; align-items: center; margin-left: 15px;">
             <h1 style="margin-bottom: 0px; padding-bottom: 0px; padding-top: 0px; margin-top: 4px;">PdfPointer</h1>

--- a/script.js
+++ b/script.js
@@ -631,7 +631,7 @@ function topAlert(text, alertType, isChange) { // Create an alert at the top of 
     if (!optionProxy.changeItems.showTips || localStorage.getItem("PDFPointer-notshow") !== null && localStorage.getItem("PDFPointer-notshow").split(",").indexOf(alertType) !== -1) return; // If the user doesn't want to see tips, or if they have requested to not show that specific alert, return
     // Create the alert container
     let alertContainer = document.createElement("div");
-    alertContainer.classList.add("vertcenter", "opacityRemove");
+    alertContainer.classList.add("vertcenter", "opacityRemove", "noselect");
     alertContainer.style = "width: 100vw; z-index: 9999998";
     let alert = document.createElement("div");
     alert.classList.add("alert", "vertcenter");

--- a/script.js
+++ b/script.js
@@ -552,6 +552,8 @@ function usefulDropdownGenerator(alertType, numberOptions, typeCustomInput) { //
         if (optionProxy.dropdownSelectedOptions[alertType] === i) dropdown.childNodes[i].style = "border-left: solid 2px var(--accent);"; else dropdown.childNodes[i].style = "padding-left: 22px";
     }
     if (typeCustomInput === "color") topAlert(globalTranslations.dropdownClose, "dropClose");
+        isFullscreen ? dropdown.style.bottom = `${parseInt(document.querySelector(`[data-action=${alertType}]`).getBoundingClientRect().bottom - dropdown.getBoundingClientRect().height + window.scrollY)}px` : dropdown.style.top = `${parseInt(document.querySelector(`[data-action=${alertType}]`).getBoundingClientRect().bottom + 75 + window.scrollY)}px`;
+
 }
 document.querySelector("[data-action=timer]").addEventListener("click", () => { // Create a dropdown timer
     usefulDropdownGenerator("timer", [`5 ${globalTranslations.seconds}`, `15 ${globalTranslations.seconds}`, `30 ${globalTranslations.seconds}`, `60 ${globalTranslations.seconds}`], "number");
@@ -570,6 +572,7 @@ function createDropdown(buttonReference, changeIcon, optionKey) {
     close.height = 25;
     close.setAttribute("data-customanimate", "1");
     close.setAttribute("draggable", "false");
+    close.setAttribute("data-closedropdown", "");
     getImg([close], changeIcon ? "fullscreenoff" : "save");
     hoverItem(close);
     close.addEventListener("click", () => { // Close the item
@@ -587,12 +590,13 @@ function createDropdown(buttonReference, changeIcon, optionKey) {
     close.classList.add("closeBtn", "saveDropdown");
     div.append(close);
     var divPosition = buttonReference.getBoundingClientRect(); // Get the page position of the button so that the dropdown will be generated a little bit below
+    console.log(buttonReference, divPosition)
     div.classList.add("dropdown");
     // If the screen is vertical, update the vertical width
     let percentageWidth = 25;
     if (screen.availHeight > screen.availWidth) { percentageWidth = 60; div.classList.add("verticalDropdown") }
-    let styleThings = `top: ${parseInt(divPosition.top) + 75 + window.scrollY}px; `;
-    if (divPosition.left + 25 + (percentageWidth * document.body.offsetWidth / 100) < document.body.offsetWidth) styleThings += `left: ${divPosition.left + 25}px; `; else styleThings += `right: ${divPosition.right - 25 - (percentageWidth * document.body.offsetWidth / 100)}px; `;
+    let styleThings = (divPosition.left + 25 + (percentageWidth * document.body.offsetWidth / 100) < document.body.offsetWidth) ? `left: ${divPosition.left + 25}px; ` : `right: ${divPosition.right - 25 - (percentageWidth * document.body.offsetWidth / 100)}px; `;
+    if (isFullscreen) styleThings = `left: ${document.getElementById("containerOfOptions").getBoundingClientRect().right  + 15}px; `;
     styleThings = styleThings.replace("right: -", "left: ").replace("left: -", "right: "); // Quick fix for dialog outside client view due to negative numbers
     div.style = styleThings;
     return div;
@@ -977,6 +981,7 @@ document.querySelector("[data-action=erase]").addEventListener("click", () => { 
 document.getElementById("displayCanvas").addEventListener("hover", intelligentCursor(document.getElementById("displayCanvas")));
 document.addEventListener('fullscreenchange', (e) => { // The user has entered or exited fullsreen
     canvasDrawCheck();
+    for (let item of document.querySelectorAll("[data-closedropdown]")) item.click(); // Close dropdowns, since they would be in the wrong position.
     if (document.fullscreenElement) { // The user is in fullscreen, adapt the UI by making the canvas bigger and moving the toolbar at the left
         isFullscreen = true;
         let getAvailableSpace = (window.innerWidth * 10 / 100) + document.getElementById("containerOfOptions").offsetWidth;
@@ -1617,6 +1622,8 @@ function createSaveImgDropdown() {
     for (let item of [select, saveBtn, slider, customText, resizeSlider, span]) hoverItem(item); // Add hover animations
     dropdown.append(document.createElement("br"), document.createElement("br"), infoLabel, document.createElement("br"), select, document.createElement("br"), document.createElement("br"), qualityContainer, document.createElement("br"), document.createElement("br"), customPage, document.createElement("br"), infoItalic, document.createElement("br"), customText, document.createElement("br"), document.createElement("br"), resizeLabel, document.createElement("br"), resizeItalic, document.createElement("br"), resizeSlider, document.createElement("br"), document.createElement("br"), checkContainer, zipText, document.createElement("br"), document.createElement("br"), saveBtn);
     document.body.append(dropdown);
+    isFullscreen ? dropdown.style.bottom = `${parseInt(document.querySelector(`[data-action=downloadAsImg]`).getBoundingClientRect().bottom - dropdown.getBoundingClientRect().height + window.scrollY)}px` : dropdown.style.top = `${parseInt(document.querySelector(`[data-action=downloadAsImg]`).getBoundingClientRect().bottom + 75 + window.scrollY)}px`;
+
 }
 function createRange(max, value, min, id, step) { // Create the slider
     let range = document.createElement("input");

--- a/style.css
+++ b/style.css
@@ -829,9 +829,9 @@ input[type='range']::-webkit-slider-thumb {
   border-radius: 50%;
 }
 .noselect {
-  -moz-user-select: text;
-  -khtml-user-select: text;
-  -webkit-user-select: text;
-  -ms-user-select: text;
-  user-select: text;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }

--- a/style.css
+++ b/style.css
@@ -15,9 +15,13 @@ body {
   background-color: var(--background);
   color: var(--text);
   font-family: 'Work Sans', sans-serif;
-  margin: 0px
+  margin: 0px;
+  -moz-user-select: text;
+  -khtml-user-select: text;
+  -webkit-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
 }
-
 .bodyProxy {
   margin: 5vw;
   margin-top: 30px;

--- a/style.css
+++ b/style.css
@@ -828,3 +828,10 @@ input[type='range']::-webkit-slider-thumb {
   padding: 10px;
   border-radius: 50%;
 }
+.noselect {
+  -moz-user-select: text;
+  -khtml-user-select: text;
+  -webkit-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}


### PR DESCRIPTION
- Don't select icons: the toolbar icons and the canvas now cannot be selected by the user. This is done to prevent blue selection while using the pen tool
- Dropdown layout improvements: they'll be closed when switching from fullscreen to normal screen (or viceversa), and their height will be taken in consideration while positioning them in the DOM